### PR TITLE
Cater for system installed fonts

### DIFF
--- a/ImperialLetterhead.cls
+++ b/ImperialLetterhead.cls
@@ -74,30 +74,33 @@
 \usepackage{fontspec} % Required for specifying custom fonts
 
 \defaultfontfeatures{Ligatures=TeX} % To support LaTeX ligatures (e.g. `` and --)
-\defaultfontfeatures{Path=Fonts/} % Specify the location of font files
+% Use system fonts if available, otherwise look in the Fonts folder.
+\IfFontExistsTF{Imperial Sans Text}{}{
+	\defaultfontfeatures{Path=Fonts/} % Specify the location of font files
+}
 
 % The default font family
-\setmainfont{ImperialSansText}[
-	UprightFont=*-Regular.ttf,
-	BoldFont=*-Bold.ttf
+\setmainfont{Imperial Sans Text}[
+	UprightFont=*-Regular,
+	BoldFont=*-Bold
 ]
 
 % The monospace font used explicitly with \texttt{}/\ttfamily
-\setmonofont{ImperialSansText}[
-	UprightFont=*-Regular.ttf,
-	BoldFont=*-Bold.ttf
+\setmonofont{Imperial Sans Text}[
+	UprightFont=*-Regular,
+	BoldFont=*-Bold
 ]
 
-\newfontfamily{\ImperialSansMedium}{ImperialSansText}[
-	UprightFont=*-Medium.ttf,
-	BoldFont=*-Bold.ttf,
+\newfontfamily{\ImperialSansMedium}{Imperial Sans Text}[
+	UprightFont=*-Medium,
+	BoldFont=*-Bold,
 ]
 
 % Define the other Imperial Sans font weights
-\newfontface{\ImperialSansExtraBold}{ImperialSansText-Extrabold.ttf}
-\newfontface{\ImperialSansExtraLight}{ImperialSansText-Extralight.ttf}
-\newfontface{\ImperialSansSemiBold}{ImperialSansText-Semibold.ttf}
-\newfontface{\ImperialSansLight}{ImperialSansText-Light.ttf}
+\newfontface{\ImperialSansExtraBold}{Imperial Sans Text Extrabold}
+\newfontface{\ImperialSansExtraLight}{Imperial Sans Text Extralight}
+\newfontface{\ImperialSansSemiBold}{Imperial Sans Text Semibold}
+\newfontface{\ImperialSansLight}{Imperial Sans Text Light}
 
 %----------------------------------------------------------------------------------------
 %	HEADERS AND FOOTERS

--- a/ImperialLetterhead.cls
+++ b/ImperialLetterhead.cls
@@ -75,32 +75,54 @@
 
 \defaultfontfeatures{Ligatures=TeX} % To support LaTeX ligatures (e.g. `` and --)
 % Use system fonts if available, otherwise look in the Fonts folder.
-\IfFontExistsTF{Imperial Sans Text}{}{
+\IfFontExistsTF{Imperial Sans Text}{
+	% The default font family
+	\setmainfont{Imperial Sans Text}[
+		UprightFont=*-Regular,
+		BoldFont=*-Bold
+	]
+
+	% The monospace font used explicitly with \texttt{}/\ttfamily
+	\setmonofont{Imperial Sans Text}[
+		UprightFont=*-Regular,
+		BoldFont=*-Bold
+	]
+
+	\newfontfamily{\ImperialSansMedium}{Imperial Sans Text}[
+		UprightFont=*-Medium,
+		BoldFont=*-Bold,
+	]
+
+	% Define the other Imperial Sans font weights
+	\newfontface{\ImperialSansExtraBold}{Imperial Sans Text Extrabold}
+	\newfontface{\ImperialSansExtraLight}{Imperial Sans Text Extralight}
+	\newfontface{\ImperialSansSemiBold}{Imperial Sans Text Semibold}
+	\newfontface{\ImperialSansLight}{Imperial Sans Text Light}
+}{
 	\defaultfontfeatures{Path=Fonts/} % Specify the location of font files
+	% The default font family
+	\setmainfont{ImperialSansText}[
+		UprightFont=*-Regular.ttf,
+		BoldFont=*-Bold.ttf
+	]
+
+	% The monospace font used explicitly with \texttt{}/\ttfamily
+	\setmonofont{ImperialSansText}[
+		UprightFont=*-Regular.ttf,
+		BoldFont=*-Bold.ttf
+	]
+
+	\newfontfamily{\ImperialSansMedium}{ImperialSansText}[
+		UprightFont=*-Medium.ttf,
+		BoldFont=*-Bold.ttf,
+	]
+
+	% Define the other Imperial Sans font weights
+	\newfontface{\ImperialSansExtraBold}{ImperialSansText-Extrabold.ttf}
+	\newfontface{\ImperialSansExtraLight}{ImperialSansText-Extralight.ttf}
+	\newfontface{\ImperialSansSemiBold}{ImperialSansText-Semibold.ttf}
+	\newfontface{\ImperialSansLight}{ImperialSansText-Light.ttf}
 }
-
-% The default font family
-\setmainfont{Imperial Sans Text}[
-	UprightFont=*-Regular,
-	BoldFont=*-Bold
-]
-
-% The monospace font used explicitly with \texttt{}/\ttfamily
-\setmonofont{Imperial Sans Text}[
-	UprightFont=*-Regular,
-	BoldFont=*-Bold
-]
-
-\newfontfamily{\ImperialSansMedium}{Imperial Sans Text}[
-	UprightFont=*-Medium,
-	BoldFont=*-Bold,
-]
-
-% Define the other Imperial Sans font weights
-\newfontface{\ImperialSansExtraBold}{Imperial Sans Text Extrabold}
-\newfontface{\ImperialSansExtraLight}{Imperial Sans Text Extralight}
-\newfontface{\ImperialSansSemiBold}{Imperial Sans Text Semibold}
-\newfontface{\ImperialSansLight}{Imperial Sans Text Light}
 
 %----------------------------------------------------------------------------------------
 %	HEADERS AND FOOTERS

--- a/ImperialLetterhead.cls
+++ b/ImperialLetterhead.cls
@@ -1,7 +1,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Imperial College London Letterhead
 % LaTeX Class
-% Version 1.0 (February 22, 2024)
+% Version 1.1 (February 29, 2024)
 %
 % For current versions and to report
 % issues, please see:

--- a/ImperialPoster.cls
+++ b/ImperialPoster.cls
@@ -102,22 +102,35 @@
 
 \defaultfontfeatures{Ligatures=TeX} % To support LaTeX ligatures (e.g. `` and --)
 % Use system fonts if available, otherwise look in the Fonts folder.
-\IfFontExistsTF{Imperial Sans Text}{}{
+\IfFontExistsTF{Imperial Sans Text}{
+	% The default font family
+	\setmainfont{Imperial Sans Text}[
+		UprightFont=*-Regular,
+		BoldFont=*-Bold
+	]
+
+	% Define the other Imperial Sans font weights
+	\newfontface{\ImperialSansExtraBold}{Imperial Sans Text Extrabold}
+	\newfontface{\ImperialSansExtraLight}{Imperial Sans Text Extralight}
+	\newfontface{\ImperialSansSemiBold}{Imperial Sans Text Semibold}
+	\newfontface{\ImperialSansMedium}{Imperial Sans Text Medium}
+	\newfontface{\ImperialSansLight}{Imperial Sans Text Light}
+}{
 	\defaultfontfeatures{Path=Fonts/} % Specify the location of font files
+
+	% The default font family
+	\setmainfont{ImperialSansText}[
+		UprightFont=*-Regular.ttf,
+		BoldFont=*-Bold.ttf
+	]
+
+	% Define the other Imperial Sans font weights
+	\newfontface{\ImperialSansExtraBold}{ImperialSansText-Extrabold.ttf}
+	\newfontface{\ImperialSansExtraLight}{ImperialSansText-Extralight.ttf}
+	\newfontface{\ImperialSansSemiBold}{ImperialSansText-Semibold.ttf}
+	\newfontface{\ImperialSansMedium}{ImperialSansText-Medium.ttf}
+	\newfontface{\ImperialSansLight}{ImperialSansText-Light.ttf}
 }
-
-% The default font family
-\setmainfont{Imperial Sans Text}[
-	UprightFont=*-Regular,
-	BoldFont=*-Bold
-]
-
-% Define the other Imperial Sans font weights
-\newfontface{\ImperialSansExtraBold}{Imperial Sans Text Extrabold}
-\newfontface{\ImperialSansExtraLight}{Imperial Sans Text Extralight}
-\newfontface{\ImperialSansSemiBold}{Imperial Sans Text Semibold}
-\newfontface{\ImperialSansMedium}{Imperial Sans Text Medium}
-\newfontface{\ImperialSansLight}{Imperial Sans Text Light}
 
 % Both {\small <text>\par} and \smalltext{<text>} will have the same effect in the template, with the latter being easier to use and the former being a standard LaTeX command
 \renewcommand{\small}{%

--- a/ImperialPoster.cls
+++ b/ImperialPoster.cls
@@ -1,7 +1,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Imperial College London Poster
 % LaTeX Class
-% Version 1.0 (February 22, 2024)
+% Version 1.1 (February 29, 2024)
 %
 % For current versions and to report
 % issues, please see:

--- a/ImperialPoster.cls
+++ b/ImperialPoster.cls
@@ -101,20 +101,23 @@
 \usepackage{fontspec} % Required for specifying custom fonts
 
 \defaultfontfeatures{Ligatures=TeX} % To support LaTeX ligatures (e.g. `` and --)
-\defaultfontfeatures{Path=Fonts/} % Specify the location of font files
+% Use system fonts if available, otherwise look in the Fonts folder.
+\IfFontExistsTF{Imperial Sans Text}{}{
+	\defaultfontfeatures{Path=Fonts/} % Specify the location of font files
+}
 
 % The default font family
-\setmainfont{ImperialSansText}[
-	UprightFont=*-Regular.ttf,
-	BoldFont=*-Bold.ttf
+\setmainfont{Imperial Sans Text}[
+	UprightFont=*-Regular,
+	BoldFont=*-Bold
 ]
 
 % Define the other Imperial Sans font weights
-\newfontface{\ImperialSansExtraBold}{ImperialSansText-Extrabold.ttf}
-\newfontface{\ImperialSansExtraLight}{ImperialSansText-Extralight.ttf}
-\newfontface{\ImperialSansSemiBold}{ImperialSansText-Semibold.ttf}
-\newfontface{\ImperialSansMedium}{ImperialSansText-Medium.ttf}
-\newfontface{\ImperialSansLight}{ImperialSansText-Light.ttf}
+\newfontface{\ImperialSansExtraBold}{Imperial Sans Text Extrabold}
+\newfontface{\ImperialSansExtraLight}{Imperial Sans Text Extralight}
+\newfontface{\ImperialSansSemiBold}{Imperial Sans Text Semibold}
+\newfontface{\ImperialSansMedium}{Imperial Sans Text Medium}
+\newfontface{\ImperialSansLight}{Imperial Sans Text Light}
 
 % Both {\small <text>\par} and \smalltext{<text>} will have the same effect in the template, with the latter being easier to use and the former being a standard LaTeX command
 \renewcommand{\small}{%

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ College London. A Beamer theme for slideshows will be released soon.
 
 ## Overleaf
 
-Current versions of these templates will be made available on Overleaf.
+The [letterhead](https://www.overleaf.com/latex/templates/imperial-college-london-official-letter-template/vxqhsxfjqdmm) and [poster](https://www.overleaf.com/latex/templates/imperial-college-london-poster-template/pphqwvtdrbkp) templates are available on Overleaf.
 
 ## Download
 


### PR DESCRIPTION
The original templates had a hard-coded font path, and were using font file names rather than human-readable names. The combination of these would cause Xelatex to fail to find the fonts if they were system-installed rather than in the Fonts subfolder of the folder containing the tex document.